### PR TITLE
Firestore - Service Account creds + document create with specific id

### DIFF
--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/DocumentDescription.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/DocumentDescription.ts
@@ -110,6 +110,19 @@ export const documentFields: INodeProperties[] = [
 		required: true,
 	},
 	{
+		displayName: 'Document ID',
+		name: 'documentId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['document'],
+				operation: ['create'],
+			},
+		},
+		default: '',
+		required: false,
+	},
+	{
 		displayName: 'Columns / Attributes',
 		name: 'columns',
 		type: 'string',

--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GoogleFirebaseCloudFirestore.node.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GoogleFirebaseCloudFirestore.node.ts
@@ -188,6 +188,7 @@ export class GoogleFirebaseCloudFirestore implements INodeType {
 					items.map(async (item: IDataObject, i: number) => {
 						const collection = this.getNodeParameter('collection', i) as string;
 						const columns = this.getNodeParameter('columns', i) as string;
+						const documentId = this.getNodeParameter('documentId', i) as string;
 						const columnList = columns.split(',').map((column) => column.trim());
 						const document = { fields: {} };
 						columnList.map((column) => {
@@ -205,6 +206,7 @@ export class GoogleFirebaseCloudFirestore implements INodeType {
 							'POST',
 							`/${projectId}/databases/${database}/documents/${collection}`,
 							document,
+							{ documentId },
 						);
 
 						responseData.id = (responseData.name as string).split('/').pop();

--- a/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GoogleFirebaseCloudFirestore.node.ts
+++ b/packages/nodes-base/nodes/Google/Firebase/CloudFirestore/GoogleFirebaseCloudFirestore.node.ts
@@ -40,9 +40,40 @@ export class GoogleFirebaseCloudFirestore implements INodeType {
 			{
 				name: 'googleFirebaseCloudFirestoreOAuth2Api',
 				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['googleFirebaseCloudFirestoreOAuth2Api'],
+					},
+				},
 			},
+			{
+				name: 'googleApi',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['serviceAccount'],
+					},
+				},
+			}
 		],
 		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				options: [
+					{
+						// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
+						name: 'OAuth2 (recommended)',
+						value: 'googleFirebaseCloudFirestoreOAuth2Api',
+					},
+					{
+						name: 'Service Account',
+						value: 'serviceAccount',
+					},
+				],
+				default: 'googleFirebaseCloudFirestoreOAuth2Api',
+			},
 			{
 				displayName: 'Resource',
 				name: 'resource',

--- a/packages/nodes-base/nodes/Google/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/GenericFunctions.ts
@@ -52,6 +52,10 @@ const googleServiceAccountScopes = {
 		'https://www.googleapis.com/auth/cloud-translation',
 		'https://www.googleapis.com/auth/cloud-platform',
 	],
+	firestore: [
+		'https://www.googleapis.com/auth/datastore',
+		'https://www.googleapis.com/auth/firebase',
+	]
 };
 
 type GoogleServiceAccount = keyof typeof googleServiceAccountScopes;


### PR DESCRIPTION
## Summary

This PR adds two features:
- Allows to use Google Service Accounts for Firestore nodes authentication.
- Allows to create Firestore documents with specific ids (optionally).

Full details at https://github.com/n8n-io/n8n/pull/9713.