### PR TITLE
chore(ci): migrate Claude workflows to onesdata claude-code-action wrapper

### DIFF
--- a/.github/workflows/util-claude-task.yml
+++ b/.github/workflows/util-claude-task.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Run Claude
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@d668cc452deb931732f24c6b1bbf24d97bc0c586 # v1
+        uses: onesdata/ops_workflows/.github/actions/claude-code-action@master
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/util-claude-task.yml
+++ b/.github/workflows/util-claude-task.yml
@@ -129,7 +129,8 @@ jobs:
         continue-on-error: true
         uses: onesdata/ops_workflows/.github/actions/claude-code-action@master
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          otel_token: ${{ secrets.COLLECTOR_PORTAL_TOKEN }}
           github_token: ${{ steps.generate_token.outputs.token }}
           prompt: ${{ env.CLAUDE_PROMPT }}
           show_full_output: ${{ inputs.suppress_output != true }}

--- a/.github/workflows/util-claude.yml
+++ b/.github/workflows/util-claude.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude PR Action
-        uses: anthropics/claude-code-action@d668cc452deb931732f24c6b1bbf24d97bc0c586 # v1
+        uses: onesdata/ops_workflows/.github/actions/claude-code-action@master
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Or use OAuth token instead:

--- a/.github/workflows/util-claude.yml
+++ b/.github/workflows/util-claude.yml
@@ -32,9 +32,8 @@ jobs:
       - name: Run Claude PR Action
         uses: onesdata/ops_workflows/.github/actions/claude-code-action@master
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Or use OAuth token instead:
-          # claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          otel_token: ${{ secrets.COLLECTOR_PORTAL_TOKEN }}
           timeout_minutes: '60'
           settings: |
             {


### PR DESCRIPTION
Cambia las referencias directas a `anthropics/claude-code-action@v1` por el wrapper de la org `onesdata/ops_workflows/.github/actions/claude-code-action@master` y añade `otel_token` para que las ejecuciones emitan telemetría OTLP a `portal.ops.onestic.com`.

**Archivos modificados:**
- `.github/workflows/util-claude-task.yml`
- `.github/workflows/util-claude.yml`

**Por qué va separado del contenido**: el Claude App rechaza autenticarse cuando el workflow del PR difiere del de la rama por defecto (medida de seguridad). Una vez este PR esté en `master`, los PRs futuros pasan la validación sin tocar nada. Patrón validado end-to-end en `onesdata/atmos-mcp#11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)